### PR TITLE
Add "topic" pages to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
   "content_scripts": [{
     "css": ["background.css", "bootstrap.css"],
     "js": ["lib/jquery.js", "background.js"],
-    "matches": ["http://imgur.com/gallery/*", "https://imgur.com/gallery/*", "http://*.imgur.com/gallery/*", "https://*.imgur.com/gallery/*", "http://imgur.com/t/*", "https://imgur.com/t/*", "http://*.imgur.com/t/*", "https://*.imgur.com/t/*"]
+    "matches": ["http://imgur.com/gallery/*", "https://imgur.com/gallery/*", "http://*.imgur.com/gallery/*", "https://*.imgur.com/gallery/*", "http://imgur.com/t/*", "https://imgur.com/t/*", "http://*.imgur.com/t/*", "https://*.imgur.com/t/*", "http://imgur.com/topic/*", "https://imgur.com/topic/*", "http://*.imgur.com/topic/*", "https://*.imgur.com/topic/*"]
   }],
   "web_accessible_resources": [
     "img/sprites.png",


### PR DESCRIPTION
I tried to sneak this in #16, but I was a minute too late.

Clicking on a tag in the gallery links to /topic/ rather than /t/. This commit just adds that to the list of pages this extension works on.
